### PR TITLE
input-leap: Add versin information to build

### DIFF
--- a/pkgs/applications/misc/input-leap/default.nix
+++ b/pkgs/applications/misc/input-leap/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  cmakeFlags = [ "-DINPUTLEAP_REVISION=${builtins.substring 0 8 src.rev}" ];
+
   buildInputs = [
     curl
     xorg.libX11


### PR DESCRIPTION
You are very quick, in my rebuild I noticed it didn't have the git hash so I was going to add it but you've already merged it :)

Feel free to just add this change to your PR if github is being difficult